### PR TITLE
doc-data-quality: use base form component for text input

### DIFF
--- a/libs/damap/src/lib/components/dmp/doc-data-quality/doc-data-quality.component.html
+++ b/libs/damap/src/lib/components/dmp/doc-data-quality/doc-data-quality.component.html
@@ -37,35 +37,27 @@
     }}
   </p>
 </app-info-message>
-<mat-form-field
-  appearance="fill"
-  [style]="'width: 100%'"
-  [floatLabel]="getFloatLabelValue()">
-  <mat-label>{{
-    "dmp.steps.documentation.question.structure" | translate
-  }}</mat-label>
-  <input matInput [placeholder]="optionsStructureAndVersioningPlaceholder" />
-</mat-form-field>
+<app-textarea-wrapper
+  [label]="'dmp.steps.documentation.question.structure' | translate"
+  [control]="structure"
+  [placeholder]="optionsStructureAndVersioningPlaceholder">
+</app-textarea-wrapper>
 
-<mat-form-field
-  appearance="fill"
-  [style]="'width: 100%'"
-  [floatLabel]="getFloatLabelValue()">
-  <mat-label>{{
-    "dmp.steps.documentation.question.convention" | translate
-  }}</mat-label>
-  <input matInput [placeholder]="optionsConventionPlaceholder" />
-</mat-form-field>
+<!-- We do not have a field for this in the back end. We have to wait until we can add custom fields in the back end and then we can have separate questions here. -->
+<!-- Also needs extra control attribute on the component and logic when (de)serializing the response from/to the backend -->
+<!-- 
+<app-textarea-wrapper
+  [label]="'dmp.steps.documentation.question.convention' | translate"
+  [control]="convention"
+  [placeholder]="optionsConventionPlaceholder">
+</app-textarea-wrapper>
 
-<mat-form-field
-  appearance="fill"
-  [style]="'width: 100%'"
-  [floatLabel]="getFloatLabelValue()">
-  <mat-label>{{
-    "dmp.steps.documentation.question.version" | translate
-  }}</mat-label>
-  <input matInput [placeholder]="optionsVersionPlaceholder" />
-</mat-form-field>
+<app-textarea-wrapper
+  [label]="'dmp.steps.documentation.question.version' | translate"
+  [control]="version"
+  [placeholder]="optionsVersionPlaceholder">
+</app-textarea-wrapper>
+-->
 
 <div class="form-field-hint">
   <mat-form-field hintLabel="Max 4000 characters" [style]="'width: 100%'">
@@ -74,10 +66,11 @@
     }}</mat-label>
     <input
       matInput
-      #input
+      #inputMetadata
+      [formControl]="metadata"
       maxlength="4000"
       placeholder=" As there are no domain specific metadata standards applicable, we will provide a README file with an explanation of all values and terms used [at file level/at dataset level/at project level]" />
-    <mat-hint align="end">{{ input.value.length }}/4000</mat-hint>
+    <mat-hint align="end">{{ inputMetadata.value.length }}/4000</mat-hint>
   </mat-form-field>
   <mat-icon
     class="tooltip-position material-icon-primary"
@@ -92,8 +85,12 @@
     <mat-label>{{
       "dmp.steps.documentation.question.documentation" | translate
     }}</mat-label>
-    <input matInput #input maxlength="4000" />
-    <mat-hint align="end">{{ input.value.length }}/4000</mat-hint>
+    <input
+      matInput
+      #inputDocumentation
+      [formControl]="documentation"
+      maxlength="4000" />
+    <mat-hint align="end">{{ inputDocumentation.value.length }}/4000</mat-hint>
   </mat-form-field>
   <mat-icon
     class="tooltip-position material-icon-primary"

--- a/libs/damap/src/lib/components/dmp/doc-data-quality/doc-data-quality.component.ts
+++ b/libs/damap/src/lib/components/dmp/doc-data-quality/doc-data-quality.component.ts
@@ -41,13 +41,12 @@ export class DocDataQualityComponent {
   ];
 
   optionsConventionPlaceholder: string =
-    '.g. “Files will be saved according to the following naming convention: [date in ISO format YYYYMMDD]_[project prefix]_[experimental  identifier]_[initials of the researcher], for instance ‘20231021_FWF7589_TFA_TM.xlsx’.” ';
+    'e.g. “Files will be saved according to the following naming convention: [date in ISO format YYYYMMDD]_[project prefix]_[experimental  identifier]_[initials of the researcher], for instance ‘20231021_FWF7589_TFA_TM.xlsx’.” ';
 
   optionsVersionPlaceholder: string =
     'e.g. “If several versions of the same data files will be performed, the individual files will be extended by v1, v2 and so forth, for instance ‘20231021_FWF7589_TFA_TM_v2.xlsx’.”';
 
   hideRequiredControl = new FormControl(false);
-  floatLabelControl = new FormControl('auto' as FloatLabelType);
   options: UntypedFormGroup;
 
   constructor(
@@ -56,7 +55,6 @@ export class DocDataQualityComponent {
   ) {
     this.options = this._formBuilder.group({
       hideRequired: this.hideRequiredControl,
-      floatLabel: this.floatLabelControl,
     });
   }
 
@@ -72,10 +70,6 @@ export class DocDataQualityComponent {
 
   openDocumentationDialog() {
     this.dialog.open(ValidationDialogInfoComponent).afterClosed().subscribe();
-  }
-
-  getFloatLabelValue(): FloatLabelType {
-    return this.floatLabelControl.value || 'auto';
   }
 
   get metadata(): UntypedFormControl {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description

<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?

<!-- Changes introduced by this PR - what happened before, what happens now -->
Comment out two fields, for which we do not have a backend pendant at the moment. It requires custom fields to be implemented.
Use base components and set attributes correctly.

Current state:
![image](https://github.com/user-attachments/assets/e15527b7-9110-45f3-9e3a-12bbeb68c406)


#### Breaking changes

<!-- Whether this PR contains breaking changes and which -->

#### Code review focus

<!-- What you want the reviewer to focus on -->

#### Dependencies

<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->

### Checks

<!-- Adjust list as necessary -->

- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes #19 
